### PR TITLE
Fix i2c dtoverlay definition in i2c_cluster_bus.md

### DIFF
--- a/content/turing_pi/children/i2c_cluster_bus.md
+++ b/content/turing_pi/children/i2c_cluster_bus.md
@@ -24,7 +24,7 @@ Turing Pi cluster management bus configuration, security and internal devices
 Add dtoverlay to /boot/config.txt and save
 
 ```
-dtoverlay=i2c1-bcm2708,sda1_pin=44,scl1_pin=45,pin_func=6
+dtoverlay=i2c1,pins_44_45
 dtoverlay=i2c-rtc,mcp7940x
 ```
 Enable I2C interface in `raspi-config` -> Interfacing Options -> I2C and reboot


### PR DESCRIPTION
It looks like the docs on the website already reflect this change, but the docs in github do not. This was a change that I had recommended in #tech-support in the discord, but didn't realize that I could just edit the docs and submit a pull request.